### PR TITLE
Implement a fast-path encoder using Unsafe access to StringBuilder internals

### DIFF
--- a/src/jmh/java/net/ckozak/EncoderHelper.java
+++ b/src/jmh/java/net/ckozak/EncoderHelper.java
@@ -1,0 +1,83 @@
+package net.ckozak;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+
+final class EncoderHelper {
+
+    /** Encode {@link CharBuffer} {@code in} into {@link ByteBuffer} {@code out}. */
+    static void encodeTo(CharsetEncoder encoder, CharBuffer in, ByteBuffer out)
+            throws CharacterCodingException
+    {
+        if (in.remaining() == 0) {
+            return;
+        }
+        encoder.reset();
+        for (;;) {
+            CoderResult cr = in.hasRemaining() ?
+                    encoder.encode(in, out, true) : CoderResult.UNDERFLOW;
+            if (cr.isUnderflow())
+                cr = encoder.flush(out);
+            if (cr.isUnderflow())
+                break;
+            // throw if overflow
+            cr.throwException();
+        }
+    }
+
+    private static final sun.misc.Unsafe unsafe;
+    private static final long coderOffset;
+    private static final long valueOffset;
+    private static final long countOffset;
+
+    static {
+        try {
+            final Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            unsafe = (sun.misc.Unsafe) field.get(null);
+            Class<?> abstractStringBuilder = Class.forName("java.lang.AbstractStringBuilder");
+            coderOffset = unsafe.objectFieldOffset(abstractStringBuilder.getDeclaredField("coder"));
+            valueOffset = unsafe.objectFieldOffset(abstractStringBuilder.getDeclaredField("value"));
+            countOffset = unsafe.objectFieldOffset(abstractStringBuilder.getDeclaredField("count"));
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    static boolean unsafeEncodeUTF8(StringBuilder buf, ByteBuffer destination) {
+        byte coder = unsafe.getByte(buf, coderOffset);
+        if (coder == 0) {
+            int len = unsafe.getInt(buf, countOffset);
+            byte[] value = (byte[]) unsafe.getObject(buf, valueOffset);
+            return unsafeEncodeUTF8FastPath(coder, value, len, destination);
+        }
+        return false;
+    }
+
+    static boolean unsafeEncodeUTF8FastPath(byte coder, byte[] val, int valLength, ByteBuffer destination) {
+        if (coder == 0 &&
+                // Cannot access the StringCoder.hasNegatives intrinsic
+                !hasNegatives(val, 0, valLength)) {
+            destination.put(val, 0, valLength);
+            return true;
+        }
+        return false;
+    }
+
+    static boolean hasNegatives(byte[] ba, int off, int len) {
+        for (int i = off; i < off + len; i++) {
+            if (ba[i] < 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private EncoderHelper() {}
+}


### PR DESCRIPTION
_Note that we're missing the `StringCoding.hasNegatives` intrinsic, which I imagine could improve performance._

This reduces the cost of encoding a StringBuilder into a ByteBuffer by half, without the optimization described above. The cost is dominated by our `hasNegatives` check.

I believe it should be possible to special case some types of inputs (`StringBuilder`, `String`) into the `CharsetEncoder` in order to perform similar optimizations to `String.getBytes` with direct access to the internal byte-array and coder value. This can be done using existing APIs if we re-introduced the recently removed internal access from `StringCharBuffer` and allow the CharsetEncoder to access this state, however we could also provide a new `CharsetEncoder` function which takes both a `CharSequence` and some form of data-sink (preferably such that we could use it without allocation, however avoiding linear allocation with the size of the message is a huge improvement).

```
Benchmark                                                      (charsetName)                          (message)  (timesToAppend)  Mode  Cnt    Score    Error  Units
EncoderBenchmarks.charsetEncoder                                       UTF-8     This is a simple ASCII message                3  avgt    4   59.227 ±  6.494  ns/op
EncoderBenchmarks.charsetEncoder                                       UTF-8  This is a message with unicode 😊                3  avgt    4  137.745 ± 24.041  ns/op
EncoderBenchmarks.charsetEncoderWithAllocation                         UTF-8     This is a simple ASCII message                3  avgt    4   71.856 ±  8.653  ns/op
EncoderBenchmarks.charsetEncoderWithAllocation                         UTF-8  This is a message with unicode 😊                3  avgt    4  140.695 ±  7.568  ns/op
EncoderBenchmarks.charsetEncoderWithAllocationWrappingBuilder          UTF-8     This is a simple ASCII message                3  avgt    4  247.414 ± 25.793  ns/op
EncoderBenchmarks.charsetEncoderWithAllocationWrappingBuilder          UTF-8  This is a message with unicode 😊                3  avgt    4  336.096 ± 42.146  ns/op
EncoderBenchmarks.encoderStringCharArray                               UTF-8     This is a simple ASCII message                3  avgt    4   92.238 ±  9.036  ns/op
EncoderBenchmarks.encoderStringCharArray                               UTF-8  This is a message with unicode 😊                3  avgt    4  165.062 ±  9.912  ns/op
EncoderBenchmarks.toStringGetBytes                                     UTF-8     This is a simple ASCII message                3  avgt    4   22.204 ±  0.120  ns/op
EncoderBenchmarks.toStringGetBytes                                     UTF-8  This is a message with unicode 😊                3  avgt    4  111.163 ± 12.518  ns/op
EncoderBenchmarks.unsafeAccess                                         UTF-8     This is a simple ASCII message                3  avgt    4   33.010 ±  3.976  ns/op
EncoderBenchmarks.unsafeAccess                                         UTF-8  This is a message with unicode 😊                3  avgt    4  132.705 ±  1.482  ns/op
```