### PR TITLE
Benchmark OutputStreamWriter against OutputStream

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 11
+sourceCompatibility = 17
 
 dependencies {
     jmhImplementation 'org.openjdk.jmh:jmh-core:1.32'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 17
+sourceCompatibility = 1.8
 
 dependencies {
     jmhImplementation 'org.openjdk.jmh:jmh-core:1.32'

--- a/src/jmh/java/net/ckozak/EncodedOutputBenchmarks.java
+++ b/src/jmh/java/net/ckozak/EncodedOutputBenchmarks.java
@@ -36,19 +36,15 @@ public class EncodedOutputBenchmarks {
         ASCII() {
             @Override
             String message() {
-                return """
-            This is a simple ASCII message. Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-            sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-            """;
+                return "This is a simple ASCII message. Lorem ipsum dolor sit amet, consectetur adipiscing elit,\n" +
+                       "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n";
             }
         },
         UNICODE() {
             @Override
             String message() {
-                return """
-            This is a message with unicode 😊 Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-            sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-            """;
+                return "This is a message with unicode 😊 Lorem ipsum dolor sit amet, consectetur adipiscing elit,\n" +
+                       "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n";
             }
         };
 

--- a/src/jmh/java/net/ckozak/EncodedOutputBenchmarks.java
+++ b/src/jmh/java/net/ckozak/EncodedOutputBenchmarks.java
@@ -1,0 +1,120 @@
+package net.ckozak;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@Measurement(iterations = 4, time = 4)
+@Warmup(iterations = 2, time = 4)
+@Fork(1)
+@Threads(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class EncodedOutputBenchmarks {
+
+    public enum Message {
+        ASCII() {
+            @Override
+            String message() {
+                return """
+            This is a simple ASCII message. Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+            sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            """;
+            }
+        },
+        UNICODE() {
+            @Override
+            String message() {
+                return """
+            This is a message with unicode 😊 Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+            sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            """;
+            }
+        };
+
+        abstract String message();
+    }
+
+    @Param
+    public Message msg;
+
+    @Param ({ "UTF-8" })
+    public String charsetName;
+
+    public String message;
+    public Charset charset;
+    public OutputStream outputStream;
+    public OutputStreamWriter outputStreamWriter;
+
+    @Setup
+    public void setup(Blackhole blackhole) throws Exception {
+        charset = Charset.forName(charsetName);
+        outputStream = new OutputStream() {
+            @Override
+            public void write(int b) {
+                blackhole.consume(b);
+            }
+
+            @Override
+            public void write(byte[] buf) {
+                blackhole.consume(buf);
+            }
+
+            @Override
+            public void write(byte[] buf, int off, int len) {
+                blackhole.consume(buf);
+                blackhole.consume(off);
+                blackhole.consume(len);
+            }
+        };
+        outputStreamWriter = new OutputStreamWriter(outputStream, charset);
+        message = msg.message();
+    }
+
+    @TearDown
+    public void tearDown() throws Exception {
+        if (outputStream != null) {
+            outputStream.close();
+        }
+        if (outputStreamWriter != null) {
+            outputStreamWriter.close();
+        }
+    }
+
+    @Benchmark
+    public void outputStreamWriter() throws Exception {
+        outputStreamWriter.write(message);
+    }
+
+    @Benchmark
+    public void getBytesToOutputStream() throws Exception {
+        outputStream.write(message.getBytes(charset));
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder()
+                .include(EncodedOutputBenchmarks.class.getSimpleName())
+                .build())
+                .run();
+    }
+}

--- a/src/jmh/java/net/ckozak/EncoderBenchmarks.java
+++ b/src/jmh/java/net/ckozak/EncoderBenchmarks.java
@@ -34,11 +34,22 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class EncoderBenchmarks {
 
-    @Param ({
-            "This is a simple ASCII message",
-            "This is a message with unicode \uD83D\uDE0A"
-    })
-    public String message;
+    public enum Message {
+        ASCII("This is a simple ASCII message", false),
+        UNICODE("This is a message with unicode \uD83D\uDE0A", false),
+        ASCII_INFLATED_BUILDER("This is a simple ASCII message", true);
+
+        private final String message;
+        private final boolean preInflateBuilder;
+
+        Message(String message, boolean preInflateBuilder) {
+            this.message = message;
+            this.preInflateBuilder = preInflateBuilder;
+        }
+    }
+
+    @Param
+    public Message message;
 
     // avoid clever inlining the string bytes directly into a result.
     @Param ({ "3" })
@@ -60,8 +71,11 @@ public class EncoderBenchmarks {
         encoder = charset.newEncoder()
                 .onMalformedInput(CodingErrorAction.REPLACE)
                 .onUnmappableCharacter(CodingErrorAction.REPLACE);
+        if (message.preInflateBuilder) {
+            stringBuilder.append("\uD83D\uDE0A").setLength(0);
+        }
         for (int i = 0; i < timesToAppend; i++) {
-            stringBuilder.append(message);
+            stringBuilder.append(message.message);
         }
     }
 


### PR DESCRIPTION
Initial results:
```
Benchmark                                       (charsetName)    (msg)  Mode  Cnt    Score    Error  Units
EncodedOutputBenchmarks.getBytesToOutputStream          UTF-8    ASCII  avgt    4   13.926 ±  0.908  ns/op
EncodedOutputBenchmarks.getBytesToOutputStream          UTF-8  UNICODE  avgt    4  110.787 ±  2.740  ns/op
EncodedOutputBenchmarks.outputStreamWriter              UTF-8    ASCII  avgt    4  105.864 ± 13.620  ns/op
EncodedOutputBenchmarks.outputStreamWriter              UTF-8  UNICODE  avgt    4  262.389 ±  7.248  ns/op
```